### PR TITLE
Optionally Include Debug Symbols/Metadata in Compiler Output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "request": "launch",
             "preLaunchTask": "Build Solution",
             "program": "${workspaceFolder}${/}Headless${/}bin${/}Debug${/}net8.0${/}Headless.dll",
-            "args": ["-l", "CSharp", "-m", "stream", "-t", "asdf"],
+            "args": ["-m", "Debug", "-l", "CSharp", "-i", "stream", "-t", "asdf"],
             "cwd": "${workspaceFolder}${/}Headless",
             "console": "integratedTerminal",
             "stopAtEntry": false
@@ -25,7 +25,7 @@
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceFolder}${/}Headless${/}bin${/}Debug${/}net8.0${/}Headless.dll",
-            "args": ["-l", "CSharp", "-m", "stream", "-t", "asdf"],
+            "args": ["-m", "Debug", "-l", "CSharp", "-i", "stream", "-t", "asdf"],
             "cwd": "${workspaceFolder}${/}Headless",
             "console": "integratedTerminal",
             "stopAtEntry": false

--- a/Headless.Core/Options/CommandLineOptions.cs
+++ b/Headless.Core/Options/CommandLineOptions.cs
@@ -4,8 +4,9 @@ namespace Headless.Core.Options;
 
 public class CommandLineOptions
 {
-    public ScriptInputMode Mode { get; set; }
+    public ScriptInputMode InputMode { get; set; }
     public string Script { get; set; } = string.Empty;
+    public RunMode RunMode { get; set; }
     public string Postamble { get; set; } = string.Empty;
 
     public string Language { get; set; } = string.Empty;

--- a/Headless.Core/Options/RunMode.cs
+++ b/Headless.Core/Options/RunMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Headless.Core.Options;
+
+public enum RunMode
+{
+    CompileAndInvoke,
+    CompileOnly,
+    Debug
+}

--- a/Headless/Extensions/ConfigurationBuilderExtensions.cs
+++ b/Headless/Extensions/ConfigurationBuilderExtensions.cs
@@ -19,12 +19,13 @@ internal static class ConfigurationBuilderExtensions
 
         builder.AddCommandLine(args, new Dictionary<string, string>
         {
+            { "-i", "inputMode" },
+            { "-s", "script" },
+            { "-m", "runMode" },
+            { "-t", "postamble" },
             { "-l", "language" },
             { "-lv", "languageVersion" },
             { "-lr", "targetRuntime" },
-            { "-m", "mode" },
-            { "-s", "script" },
-            { "-t", "postamble" },
             { "--js-strict", "JavaScriptInterpreter:StrictMode" }
         });
     }

--- a/Headless/Extensions/ServiceCollectionExtensions.cs
+++ b/Headless/Extensions/ServiceCollectionExtensions.cs
@@ -51,9 +51,9 @@ internal static class ServiceCollectionExtensions
 
         return services
             .Configure<CommandLineOptions>(hostBuilder.Configuration)
-            .Configure<JavaScriptInterpreterOptions>(hostBuilder.Configuration)
+            .Configure<JavaScriptInterpreterOptions>(hostBuilder.Configuration.GetSection("JavaScriptInterpreter"))
             .AddSingleton<CommandLineOptions>(provider => provider.GetRequiredService<IOptions<CommandLineOptions>>().Value)
-            .AddSingleton<JavaScriptInterpreterOptions>(provider => provider.GetRequiredService<IOptions<CommandLineOptions>>().Value.JavaScriptInterpreter);
+            .AddSingleton<JavaScriptInterpreterOptions>(provider => provider.GetRequiredService<IOptions<JavaScriptInterpreterOptions>>().Value);
     }
 
     public static void AddHeadlessServices(HostBuilderContext hostBuilder, IServiceCollection services) => services.AddHeadlessServices(hostBuilder);

--- a/Headless/Headless.csproj
+++ b/Headless/Headless.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Headless.Core\Headless.Core.csproj" />
-
     <EmbeddedResource Include="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <Link>%(Filename)%(Extension)</Link>
@@ -27,16 +26,7 @@
     </EmbeddedResource>
     <EmbeddedResource Remove="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*Headless.Core.*" />
     <EmbeddedResource Remove="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*Microsoft.Extensions.*" />
-
-    <!-- <Content Include="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*">
-      <Link>%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <IsAssembly>true</IsAssembly>
-      <PublishState>Default</PublishState>
-      <Visible>False</Visible>
-    </Content>
-    <Content Remove="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*Headless.Core.dll">
-    </Content> -->
+    <EmbeddedResource Remove="..\Headless.Targeting.*\bin\$(Configuration)\$(TargetFramework)\*.deps.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Headless/Program.cs
+++ b/Headless/Program.cs
@@ -5,7 +5,7 @@
 
 using var scope = host.Services.CreateScope();
 var options = scope.ServiceProvider.GetRequiredService<CommandLineOptions>();
-var script = options.Mode switch
+var script = options.InputMode switch
 {
     ScriptInputMode.File => new StringBuilder(File.ReadAllText(options.Script)),
     ScriptInputMode.Stream => new Func<StringBuilder>(() =>
@@ -29,14 +29,14 @@ if (script.Length == 0)
 
 Console.Out.WriteLine($"{Environment.NewLine}-------------OUTPUT-------------{Environment.NewLine}");
 
-var compileTaskTimedResult = await TimedTask.Run(() => scope.ServiceProvider.GetRequiredKeyedService<IScriptCompiler>(options.TargetKey).Compile(script.ToString()));
+var compileTaskTimedResult = await scope.ServiceProvider.GetRequiredKeyedService<IScriptCompiler>(options.TargetKey).Compile(script.ToString()).WithTimer();
 if (compileTaskTimedResult.TaskResult.IsSuccess)
 {
-    var invokeTaskTimedResult = await TimedTask.Run(() => scope.ServiceProvider.GetRequiredKeyedService<IScriptInvoker>(options.TargetKey).Run<object>(compileTaskTimedResult.TaskResult));
+    var invokeTaskTimedResult = await scope.ServiceProvider.GetRequiredKeyedService<IScriptInvoker>(options.TargetKey).Run<object>(compileTaskTimedResult.TaskResult).WithTimer();
     if (invokeTaskTimedResult.TaskResult.IsSuccess)
     {
-        Console.Out.WriteLine($"COMPILED IN: {compileTaskTimedResult.TaskDuration.TotalMilliseconds:N2} ms");
-        Console.Out.WriteLine($"EXECUTED IN: {invokeTaskTimedResult.TaskDuration.TotalMilliseconds:N2} ms{Environment.NewLine}");
+        Console.Out.WriteLine($"COMPILED IN: {compileTaskTimedResult.TaskDuration:ss\\.fffffff} s");
+        Console.Out.WriteLine($"EXECUTED IN: {invokeTaskTimedResult.TaskDuration:ss\\.fffffff} s{Environment.NewLine}");
         Console.Out.WriteLine($"RESULT VALUE: {invokeTaskTimedResult.TaskResult.Result}");
     }
     else

--- a/Headless/Properties/launchSettings.json
+++ b/Headless/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Headless": {
       "commandName": "Project",
-      "commandLineArgs": "-m stream -t asdf -l JavaScript -lv latest --js-strict"
-      //"commandLineArgs": "-m stream -t asdf -l CSharp -lv latest"
+      //"commandLineArgs": "-l JavaScript -i stream -t asdf -lv latest --js-strict"
+      "commandLineArgs": "-m Debug -l CSharp -i stream -t asdf"
     }
   }
 }


### PR DESCRIPTION
This is just a small PR which adds in a new command line option `RunMode`. You will now be able to specify the run mode of the script, and specifying `Debug` will instruct the target script interpreter to include debug symbols/metadata/etc into the compiler output. Currently only C# is supported, but I intend to get to the JavaScript interpreter next.

This is of course in preparation for upcoming functionality in prototyper to make use of the native debugging capabilities in VSCode. These proposed improvements will allow you to debug Headless scripts within VSCode.

**This does introduce some breaking changes**  due to some command line options having to be renamed - these changes can be reviewed in `./Headless/Extensions/ConfigurationBuilderExtensions.cs`.

Also I snuck in some small unrelated refactors to the host application and DI configuration which improve performance of all compilers and add a little more convenient management of the application configuration, amongst other things.